### PR TITLE
Fetch bootstrap-sass from rubygems instead of github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'coffee-rails', '~> 4.0.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'bootstrap-sass', github: 'thomas-mcdonald/bootstrap-sass', branch: '3'
+gem 'bootstrap-sass', '~> 3.0.3.0'
 gem 'jquery-turbolinks'
 gem 'masonry-rails', '~> 0.2.0'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,14 +54,6 @@ GIT
       tzinfo (~> 0.3.37)
 
 GIT
-  remote: git://github.com/thomas-mcdonald/bootstrap-sass.git
-  revision: 9c6c07f74ff515cf38380b014cfede14a4f0eae4
-  branch: 3
-  specs:
-    bootstrap-sass (3.0.0.0)
-      sass (~> 3.2)
-
-GIT
   remote: https://github.com/francisd/rails3-jquery-autocomplete
   revision: 9884a40f2bb1a8fa3ffab445e6d2c74c3ee99a0d
   specs:
@@ -110,6 +102,8 @@ GEM
     better_errors (1.0.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
+    bootstrap-sass (3.0.3.0)
+      sass (~> 3.2)
     bson (2.0.0.rc3)
     bson_ext (1.5.1)
     builder (3.1.4)
@@ -414,7 +408,7 @@ DEPENDENCIES
   active_model_serializers
   autoprefixer-rails
   better_errors
-  bootstrap-sass!
+  bootstrap-sass (~> 3.0.3.0)
   bson_ext
   cache_digests
   cancan


### PR DESCRIPTION
The bootstrap-sass gem now uses twbs/bootstrap version 3 by default and
no longer in release candidate status. Also, it was breaking when I tried to bundle install on my machine.
![opendevdata](https://f.cloud.github.com/assets/2944985/1773680/8fb4e1d6-67ed-11e3-8e54-7daa7dbff123.png)
